### PR TITLE
Update opencti_intrusion_set.py

### DIFF
--- a/pycti/entities/opencti_intrusion_set.py
+++ b/pycti/entities/opencti_intrusion_set.py
@@ -286,9 +286,33 @@ class IntrusionSet:
                 "orderMode": order_mode,
             },
         )
-        return self.opencti.process_multiple(
-            result["data"]["intrusionSets"], with_pagination
-        )
+        if get_all:
+            final_data = []
+            data = self.opencti.process_multiple(result["data"]["intrusionSets"])
+            final_data = final_data + data
+            while result["data"]["intrusionSets"]["pageInfo"]["hasNextPage"]:
+                after = result["data"]["intrusionSets"]["pageInfo"]["endCursor"]
+                self.opencti.app_logger.info(
+                    "Listing Intrusion-Sets", {"after": after}
+                )
+                result = self.opencti.query(
+                    query,
+                    {
+                        "filters": filters,
+                        "search": search,
+                        "first": first,
+                        "after": after,
+                        "orderBy": order_by,
+                        "orderMode": order_mode,
+                    },
+                )
+                data = self.opencti.process_multiple(result["data"]["intrusionSets"])
+                final_data = final_data + data
+            return final_data
+        else:
+            return self.opencti.process_multiple(
+                result["data"]["intrusionSets"], with_pagination
+            )
 
     """
         Read a Intrusion-Set object


### PR DESCRIPTION
Bug fix for issue #586

The intrusion_set.list(getAll=True) method retrieves up to 500 records only even if the dataset contains more than 500 records.

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add code to the list() method to retrieve additional rows of Intrusion-Set objects beyond the first 500 rows if when getAll is True. 
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
